### PR TITLE
Replace xz with gzip

### DIFF
--- a/files/pg-backup
+++ b/files/pg-backup
@@ -62,7 +62,7 @@ exec 2>&1
 pg_dumpall \
   --clean  \
   --if-exists \
-| xz -9 > "pg_cluster-$today.sql.xz" \
+| gzip -1 > "pg_cluster-$today.sql.gz" \
 || failed "pg_cluster"
 
 # Dump individual databases


### PR DESCRIPTION
xz -9 takes three+ hours to complete
gzip -1 takes about two minutes sixteen seconds

Based upon my sample set (pg_cluster-2021-01-04.sql):

```
Compression | Compressed % |   Time   | Mebibytes Saved per Second
------------+--------------+----------+---------------------------
gzip -1     | 32.9%        |  136.595 | 42.12
gzip        | 27.9%        |  458.370 | 13.47
gzip -9     | 27.5%        | 1400.918 |  4.44
xz -1       | 26.8%        |  792.308 |  7.92
```

Takeaway:
* gzip -9 takes longer than xz -1, and produces a larger file
* xz -9 takes way too long
* gzip -1 provides great return on value
* proper backup culling will keep space usage in check