### PR TITLE
Install RPM GPG Key for PGDG yum repository

### DIFF
--- a/tasks/repo.yml
+++ b/tasks/repo.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: "Install Postgres Repository GPG key"
+  rpm_key:
+    key: https://www.postgresql.org/download/keys/RPM-GPG-KEY-PGDG
+    state: present
+    validate_certs: true
+
 - name: "Install Postgres Repository"
   package:
     name: https://download.postgresql.org/pub/repos/yum/reporpms/EL-{{ ansible_distribution_major_version }}-{{ ansible_machine }}/pgdg-redhat-repo-latest.noarch.rpm


### PR DESCRIPTION
On RHEL 8:
TASK [uclalib_role_postgresql : Install Postgres Repository] ******************* fatal: [p-w-zabbix01-rhel8.library.ucla.edu]: FAILED! => changed=false
  msg: Failed to validate GPG signature for pgdg-redhat-repo-42.0-34PGDG.noarch